### PR TITLE
Updates cors origin to config.host.name

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -45,7 +45,7 @@ mongoose.connect(config.db.mlab, {
 
 app.use(
   cors({
-    origin: 'https://www.projectmatch.me',
+    origin: config.host.name,
     credentials: true,
     preflightContinue: true,
     optionsSuccessStatus: 200


### PR DESCRIPTION
Previously, CORS was hard-linked to https://www.projectmatch.me which breaks the development environment when running localhost:3000.
